### PR TITLE
Add the number of players as a command line argument

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,6 +1,36 @@
+from argparse import ArgumentParser
+
 import cozmo
 
 from song_match import SongMatch
 
-song_match = SongMatch()
-cozmo.run_program(song_match.play)
+
+def main():
+    args = parse_args()
+    num_players = args['num_players']
+    song_match = SongMatch(num_players=num_players)
+    cozmo.run_program(song_match.play)
+
+
+def parse_args() -> dict:
+    arg_parser = ArgumentParser(description='Play Song Match with Cozmo.')
+    num_players_argument_kwargs = get_num_players_argument_kwargs()
+    arg_parser.add_argument('-p', **num_players_argument_kwargs)
+    args = arg_parser.parse_args()
+    return vars(args)
+
+
+def get_num_players_argument_kwargs() -> dict:
+    return {
+        'action': 'store',
+        'dest': 'num_players',
+        'metavar': 'N',
+        'type': int,
+        'choices': range(1, 6),
+        'help': 'The number of players for the game.',
+        'default': 1
+    }
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
I made the number of players for the game configurable as a command line argument.

It defaults to **1** player, and the max number of players is **5**.

`$ python main.py -h`

```
usage: main.py [-h] [-p N]

Play Song Match with Cozmo.

optional arguments:
  -h, --help  show this help message and exit
  -p N        The number of players for the game.
```